### PR TITLE
Pass FSWatcher.path to notification callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.4
+  - Add full path argument to those passed to notification callback.
+
 ## 0.0.3
   - Compare time based on their numeric value, a regular compare.
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ var files = [
 ];
 
 var notifications = new Notify(files);
-notifications.on('change', function (file) {
-  console.log('file changed');
+notifications.on('change', function (file, event, path) {
+  console.log('caught a ' + event + ' event on ' + path);
 });
 
 // if you want to add more files you can use the

--- a/notify.js
+++ b/notify.js
@@ -233,7 +233,7 @@ Notify.prototype.ensure = function ensure(path, fn) {
 Notify.prototype.change = function change(FSWatcher, event, filename) {
   if (!filename) return this.manually(FSWatcher, event).reset(FSWatcher.path);
 
-  this.emit('change', filename, event);
+  this.emit('change', filename, event, FSWatcher.path);
   this.reset(FSWatcher.path);
 
   return this;

--- a/package.json
+++ b/package.json
@@ -22,5 +22,5 @@
     "type": "git",
     "url": "git@github.com:3rd-Eden/fs.notify.git"
   },
-  "version": "0.0.3"
+  "version": "0.0.4"
 }


### PR DESCRIPTION
This pull request contains the change described in [https://github.com/3rd-Eden/fs.notify/issues/3](bigmonkeyboy's issue), which I'd argue is vital to the "not sucking hairy monkey balls" goal of the project, in that a callback, unable to tell on precisely which file it's receiving a notification, lacks enough utility that it can still be described as sucking at least one hairy monkey ball.

I acknowledge that there's no test included here, such as you requested from bigmonkeyboy. I'm not sure what you have in mind for such a test to cover, since your repo doesn't contain any preexisting tests on which to build. If you're unwilling to accept the pull request in its absence, then let me know what cases the test should include, and I'll submit another pull request with a test which meets those requirements.
